### PR TITLE
fix(render version schema): push detached HEAD to master

### DIFF
--- a/src/scripts/releaser/render-version-schema.sh
+++ b/src/scripts/releaser/render-version-schema.sh
@@ -7,4 +7,5 @@ bash <(curl https://raw.githubusercontent.com/ory/cli/master/install.sh) -b $GOP
 
 ory dev schema render-version $CIRCLE_PROJECT_REPONAME $CIRCLE_TAG
 git commit -a -m "autogen: add $CIRCLE_TAG to version.schema.json"
-git push --set-upstream origin $CIRCLE_BRANCH
+# pushing detached HEAD to master
+git push origin HEAD:master


### PR DESCRIPTION
There should be no conflicts with this because it will be triggered right after a release. See https://app.circleci.com/pipelines/github/ory/hydra/1163/workflows/d44d5b82-c066-4962-851a-13d2f8e2de72/jobs/22544 for my debugging attempt.