### PR TITLE
feat: docs format check command

### DIFF
--- a/src/orbs/changelog.yml
+++ b/src/orbs/changelog.yml
@@ -5,7 +5,7 @@ executors:
   default:
     docker:
       -
-        image: circleci/node:13
+        image: circleci/node:14
 
 jobs:
   generate:

--- a/src/orbs/docs.yml
+++ b/src/orbs/docs.yml
@@ -7,7 +7,15 @@ executors:
       -
         image: circleci/golang:1.14-node
         environment:
-          - GO111MODULE=on
+          GO111MODULE: "on"
+
+commands:
+  check-format:
+    steps:
+      - run:
+          command: |-
+            cd docs
+            npm run format:check
 
 jobs:
   cli:

--- a/src/orbs/docs.yml
+++ b/src/orbs/docs.yml
@@ -5,7 +5,7 @@ executors:
   default:
     docker:
       -
-        image: circleci/golang:1.14-node
+        image: circleci/golang:1.15-node
         environment:
           GO111MODULE: "on"
 

--- a/src/orbs/docs.yml
+++ b/src/orbs/docs.yml
@@ -15,7 +15,7 @@ commands:
       - run:
           command: |-
             cd docs
-            npx prettier@"$(cat package.json | jq -r .devDependencies.prettier)" --check "$(cat package.json | jq -r .consts.prettierTarget)" $(cat package.json | jq -r .consts.prettierArgs)
+            npm run format:check
 
 jobs:
   cli:

--- a/src/orbs/docs.yml
+++ b/src/orbs/docs.yml
@@ -15,7 +15,7 @@ commands:
       - run:
           command: |-
             cd docs
-            npm run format:check
+            npx prettier@"$(cat package.json | jq -r .devDependencies.prettier)" --check "$(cat package.json | jq -r .consts.prettierTarget)" $(cat package.json | jq -r .consts.prettierArgs)
 
 jobs:
   cli:

--- a/src/orbs/docs.yml
+++ b/src/orbs/docs.yml
@@ -15,7 +15,8 @@ commands:
       - run:
           command: |-
             cd docs
-            npx prettier@"$(cat package.json | jq -r .devDependencies.prettier)" --check "$(cat package.json | jq -r .consts.prettierTarget)" $(cat package.json | jq -r .consts.prettierArgs)
+            npm ci
+            npm run format:check
 
 jobs:
   cli:

--- a/src/orbs/golangci.yml
+++ b/src/orbs/golangci.yml
@@ -1,20 +1,9 @@
 version: 2.1
 description: Run gloangci tools
 
-executors:
-  default:
-    docker:
-      -
-        image: circleci/golang:1.14
-        environment:
-          - GO111MODULE=on
-
-jobs:
+commands:
   lint:
-    executor: default
     steps:
-      - checkout
-      - checkout
       -
         restore_cache:
           keys:
@@ -33,8 +22,8 @@ jobs:
         run: GOGC=20 golangci-lint run
 
 examples:
-  nancy:
-    description: Test go.mod for CVEs using nancy
+  lint:
+    description: Lint using golangci-lint
     usage:
       version: 2.1
       orbs:
@@ -42,4 +31,7 @@ examples:
       workflows:
         lint:
           jobs:
-            - golangci/lint
+            run-linter:
+              steps:
+                - checkout
+                - foo/lint

--- a/src/orbs/golangci.yml
+++ b/src/orbs/golangci.yml
@@ -7,7 +7,7 @@ executors:
       -
         image: circleci/golang:1.15
         environment:
-          GO111MODULE: on
+          GO111MODULE: 'on'
 
 commands:
   lint:

--- a/src/orbs/golangci.yml
+++ b/src/orbs/golangci.yml
@@ -1,6 +1,14 @@
 version: 2.1
 description: Run gloangci tools
 
+executors:
+  default:
+    docker:
+      -
+        image: circleci/golang:1.15
+        environment:
+          GO111MODULE: on
+
 commands:
   lint:
     steps:
@@ -17,7 +25,7 @@ commands:
             - "/go/pkg/mod"
       -
         #  TODO: update to >1.24.0 - see https://github.com/golangci/golangci-lint/issues/994
-        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
+        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
       -
         run: GOGC=20 golangci-lint run
 

--- a/src/orbs/goreleaser.yml
+++ b/src/orbs/goreleaser.yml
@@ -5,13 +5,13 @@ executors:
   default:
     docker:
       -
-        image: oryd/xgoreleaser:1.14.6-0.140.1
+        image: oryd/xgoreleaser:latest
         environment:
           - GO111MODULE=on
   node:
     docker:
       -
-        image: circleci/golang:1.14-node
+        image: circleci/golang:1.15-node
         environment:
           - GO111MODULE=on
 

--- a/src/orbs/nancy.yml
+++ b/src/orbs/nancy.yml
@@ -5,7 +5,7 @@ executors:
   default:
     docker:
       -
-        image: circleci/golang:1.14
+        image: circleci/golang:1.15
         environment:
           - GO111MODULE=on
 

--- a/src/orbs/sdk.yml
+++ b/src/orbs/sdk.yml
@@ -5,7 +5,7 @@ executors:
   default:
     docker:
       -
-        image: circleci/golang:1.14
+        image: circleci/golang:1.15
         environment:
           - GO111MODULE=on
 

--- a/src/scripts/changelog/generate.sh
+++ b/src/scripts/changelog/generate.sh
@@ -35,9 +35,9 @@ printf "# Changelog\n\n" | cat - CHANGELOG.md > "$t" && mv "$t" CHANGELOG.md
 
 if [ -z ${isRelease+x} ]; then
   git add -A
-  (git commit -m "$COMMIT_MESSAGE" -- CHANGELOG.md && git push origin HEAD:$CIRCLE_BRANCH) || true
+  (git commit -m "$COMMIT_MESSAGE" -- CHANGELOG.md && git pull -ff && git push origin HEAD:$CIRCLE_BRANCH) || true
 else
   git checkout -b "changelog-$(date +"%m-%d-%Y")"
   git add -A
-  (git commit -m "$COMMIT_MESSAGE" -- CHANGELOG.md && git push origin HEAD:master) || true
+  (git commit -m "$COMMIT_MESSAGE" -- CHANGELOG.md && git pull -ff && git push origin HEAD:master) || true
 fi

--- a/src/scripts/changelog/generate.sh
+++ b/src/scripts/changelog/generate.sh
@@ -37,7 +37,9 @@ if [ -z ${isRelease+x} ]; then
   git add -A
   (git commit -m "$COMMIT_MESSAGE" -- CHANGELOG.md && git pull -ff && git push origin HEAD:$CIRCLE_BRANCH) || true
 else
-  git checkout -b "changelog-$(date +"%m-%d-%Y")"
   git add -A
+  git fetch origin
+  git checkout -b "changelog-$(date +"%m-%d-%Y")" origin/master
+  git pull -ff
   (git commit -m "$COMMIT_MESSAGE" -- CHANGELOG.md && git pull -ff && git push origin HEAD:master) || true
 fi

--- a/src/scripts/docs/build.sh
+++ b/src/scripts/docs/build.sh
@@ -35,6 +35,8 @@ if [ -n "${CIRCLE_TAG+x}" ]; then
   (cd docs; npm run docusaurus docs:version "$doc_tag")
 fi
 
+export TERSER_PARALLEL=false
+
 (cd docs; \
   npm run format && \
   npm run build

--- a/src/scripts/releaser/render-version-schema.sh
+++ b/src/scripts/releaser/render-version-schema.sh
@@ -7,4 +7,5 @@ bash <(curl https://raw.githubusercontent.com/ory/cli/master/install.sh) -b $GOP
 
 ory dev schema render-version $CIRCLE_PROJECT_REPONAME $CIRCLE_TAG
 git commit -a -m "autogen: add $CIRCLE_TAG to version.schema.json"
-git push --set-upstream origin $CIRCLE_BRANCH
+# pushing detached HEAD to master
+git push origin HEAD:master

--- a/src/scripts/releaser/test.sh
+++ b/src/scripts/releaser/test.sh
@@ -5,8 +5,10 @@ set -Eeuox pipefail
 hub=${DOCKER_HUB_NAME:-oryd}
 
 BINARY_NAME=$CIRCLE_PROJECT_REPONAME
+DOCKER_NAME=$CIRCLE_PROJECT_REPONAME
 if [[ $CIRCLE_PROJECT_REPONAME == "cli" ]]; then
   BINARY_NAME="ory"
+  DOCKER_NAME="ory"
 fi
 
 curl -sSfL \
@@ -17,6 +19,6 @@ curl -sSfL \
 "./bin/${BINARY_NAME}" version | grep -q "${CIRCLE_TAG}" || exit 1
 
 docker run --rm \
-  "${hub}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}" help
+  "${hub}/${DOCKER_NAME}:${CIRCLE_TAG}" help
 docker run --rm \
-  "${hub}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}" version | grep -q "${CIRCLE_TAG}" || exit 1
+  "${hub}/${DOCKER_NAME}:${CIRCLE_TAG}" version | grep -q "${CIRCLE_TAG}" || exit 1


### PR DESCRIPTION
This adds a command to the docs orb that runs `prettier --check` in the docs subfolder.
Note that I am using `jq` and `npx` to work around the need to run `npm i`.

BREAKING CHANGE:
The golangci orb now defines a lint command instead of a job. This allows the usage of both `golangci-lint` and `prettier --check` in one job, i.e. with less overhead.