### PR TITLE
feat: add docs format check command

### DIFF
--- a/src/orbs/docs.yml
+++ b/src/orbs/docs.yml
@@ -7,7 +7,16 @@ executors:
       -
         image: circleci/golang:1.15-node
         environment:
-          - GO111MODULE=on
+          GO111MODULE: 'on'
+
+commands:
+  check-format:
+    steps:
+      - run:
+          command: |-
+            cd docs
+            npm ci
+            npm run format:check
 
 jobs:
   cli:

--- a/src/orbs/golangci.yml
+++ b/src/orbs/golangci.yml
@@ -7,14 +7,11 @@ executors:
       -
         image: circleci/golang:1.15
         environment:
-          - GO111MODULE=on
+          GO111MODULE: 'on'
 
-jobs:
+commands:
   lint:
-    executor: default
     steps:
-      - checkout
-      - checkout
       -
         restore_cache:
           keys:
@@ -27,14 +24,13 @@ jobs:
           paths:
             - "/go/pkg/mod"
       -
-        #  TODO: update to >1.24.0 - see https://github.com/golangci/golangci-lint/issues/994
         run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
       -
         run: GOGC=20 golangci-lint run
 
 examples:
-  nancy:
-    description: Test go.mod for CVEs using nancy
+  lint:
+    description: Lint using golangci-lint
     usage:
       version: 2.1
       orbs:
@@ -42,4 +38,7 @@ examples:
       workflows:
         lint:
           jobs:
-            - golangci/lint
+            run-linter:
+              steps:
+                - checkout
+                - foo/lint


### PR DESCRIPTION
BREAKING CHANGE:
The golangci orb now defines a lint command instead of a job. This allows the usage of both golangci-lint and prettier --check in one job, i.e. with less overhead.