### PR TITLE
fix: use sudo to install prettier globally

### DIFF
--- a/src/scripts/install/prettier.sh
+++ b/src/scripts/install/prettier.sh
@@ -4,4 +4,4 @@ set -Eeuox pipefail
 
 mkdir -p node_modules/ory-prettier-styles
 tar -xf "$(npm pack ory-prettier-styles)" -C node_modules/ory-prettier-styles --strip-components=1
-npm i -g prettier
+sudo npm i -g prettier


### PR DESCRIPTION
Required in CCI and GH actions