### PR TITLE
feat: generate faq

### DIFF
--- a/src/scripts/docs/build.sh
+++ b/src/scripts/docs/build.sh
@@ -23,6 +23,7 @@ swagger validate "${SWAG_SPEC_LOCATION}"
 
 npx widdershins@3.6.7 -u docs/.widdershins/templates -e docs/.widdershins/config.json "$SWAG_SPEC_LOCATION" -o ./docs/docs/reference/api.mdx
 
+node ./docs/scripts/gen-faq.js
 node ./docs/scripts/fix-api.js ./docs/docs/reference/api.mdx
 node ./docs/scripts/config.js docs/config.js
 

--- a/src/scripts/docs/build.sh
+++ b/src/scripts/docs/build.sh
@@ -28,7 +28,7 @@ npx widdershins@3.6.7 -u docs/.widdershins/templates -e docs/.widdershins/config
 # node ./docs/scripts/config.js docs/config.js
 # replace with npm run gen, runs in projects with /docs
 
-npm run gen
+(cd docs; npm run gen)
 
 if [ -n "${CIRCLE_TAG+x}" ]; then
   doc_tag=$(echo "${CIRCLE_TAG}" | cut -d '+' -f1 | cut -d '.' -f-2)

--- a/src/scripts/docs/build.sh
+++ b/src/scripts/docs/build.sh
@@ -23,9 +23,12 @@ swagger validate "${SWAG_SPEC_LOCATION}"
 
 npx widdershins@3.6.7 -u docs/.widdershins/templates -e docs/.widdershins/config.json "$SWAG_SPEC_LOCATION" -o ./docs/docs/reference/api.mdx
 
-node ./docs/scripts/gen-faq.js
-node ./docs/scripts/fix-api.js ./docs/docs/reference/api.mdx
-node ./docs/scripts/config.js docs/config.js
+# node ./docs/scripts/gen-faq.js
+# node ./docs/scripts/fix-api.js ./docs/docs/reference/api.mdx
+# node ./docs/scripts/config.js docs/config.js
+# replace with npm run gen, runs in projects with /docs
+
+npm run gen
 
 if [ -n "${CIRCLE_TAG+x}" ]; then
   doc_tag=$(echo "${CIRCLE_TAG}" | cut -d '+' -f1 | cut -d '.' -f-2)


### PR DESCRIPTION
Added a command to generate the FAQ as specified in this PR: https://github.com/ory/kratos/pull/1039.

In order to split up the FAQ generation as proposed in this [comment](https://github.com/ory/kratos/pull/1039#issuecomment-775967979):
Here are the scripts: https://github.com/ory/docusaurus-template/pull/66
Here lives the .yaml for Kratos: https://github.com/ory/kratos/pull/1039
In this PR we added the command to run the script to the documentation build pipeline: https://github.com/ory/ci/pull/45