### PR TITLE
feat(docs/build): allow to ignore multiple packages

### DIFF
--- a/src/orbs/docs.yml
+++ b/src/orbs/docs.yml
@@ -31,7 +31,7 @@ jobs:
         type: string
         default: .schema/api.swagger.json
       swag-spec-ignore:
-        description: Packages to ignore when generating the Swagger spec.
+        description: Packages to ignore when generating the Swagger spec (space delimited).
         type: string
         default: internal/httpclient
     executor: default

--- a/src/scripts/docs/build.sh
+++ b/src/scripts/docs/build.sh
@@ -14,7 +14,10 @@ bash <(curl -s https://raw.githubusercontent.com/ory/ci/master/src/scripts/insta
 bash <(curl -s https://raw.githubusercontent.com/ory/ci/master/src/scripts/install/git.sh)
 bash <(curl https://raw.githubusercontent.com/ory/cli/master/install.sh) -b $GOPATH/bin
 
-swagger generate spec -m -o "${SWAG_SPEC_LOCATION}" -x "${SWAG_SPEC_IGNORE}"
+# we want word splitting here to pass the args
+# shellcheck disable=SC2046
+# shellcheck disable=SC2086
+swagger generate spec -m -o "${SWAG_SPEC_LOCATION}" $(printf -- " -x %s" ${SWAG_SPEC_IGNORE})
 ory dev swagger sanitize "${SWAG_SPEC_LOCATION}"
 swagger flatten --with-flatten=remove-unused -o "${SWAG_SPEC_LOCATION}" "${SWAG_SPEC_LOCATION}"
 swagger validate "${SWAG_SPEC_LOCATION}"


### PR DESCRIPTION
This allows to ignore multiple packages by passing them space delimited to the `swag-spec-ignore` parameter.

Tested locally using:
```shell
$ SWAG_SPEC_IGNORE="internal/httpclient proto/ory/keto docker"
$ .bin/swagger generate spec -m $(printf -- " -x %s" ${SWAG_SPEC_IGNORE}) | grep "internal/http"
$ .bin/swagger generate spec -m $(printf -- " -x %s" ${SWAG_SPEC_IGNORE}) | grep "proto"
```
which resulted in no output, as expected.