### PR TITLE
fix(docs): remove obsolete npx widdershins

### DIFF
--- a/src/scripts/docs/build.sh
+++ b/src/scripts/docs/build.sh
@@ -22,16 +22,7 @@ ory dev swagger sanitize "${SWAG_SPEC_LOCATION}"
 swagger flatten --with-flatten=remove-unused -o "${SWAG_SPEC_LOCATION}" "${SWAG_SPEC_LOCATION}"
 swagger validate "${SWAG_SPEC_LOCATION}"
 
-(cd docs; npm i)
-
-npx widdershins@3.6.7 -u docs/.widdershins/templates -e docs/.widdershins/config.json "$SWAG_SPEC_LOCATION" -o ./docs/docs/reference/api.mdx
-
-# node ./docs/scripts/gen-faq.js
-# node ./docs/scripts/fix-api.js ./docs/docs/reference/api.mdx
-# node ./docs/scripts/config.js docs/config.js
-# replace with npm run gen, runs in projects with /docs
-
-(cd docs; npm run gen)
+(cd docs; npm i; npm run gen)
 
 if [ -n "${CIRCLE_TAG+x}" ]; then
   doc_tag=$(echo "${CIRCLE_TAG}" | cut -d '+' -f1 | cut -d '.' -f-2)


### PR DESCRIPTION
Widdershins is run as part of `npm run gen` since quite some time now.