### PR TITLE
chore(sdk): remove goreturns install

### DIFF
--- a/src/orbs/sdk.yml
+++ b/src/orbs/sdk.yml
@@ -99,7 +99,6 @@ jobs:
             jq -r '.assets[] | select(.name | contains("'"$(uname | tr '[:upper:]' '[:lower:]')"'_amd64")) | .browser_download_url')
           sudo curl -o $GOPATH/bin/swagger -L'#' "$download_url"
           sudo chmod +x $GOPATH/bin/swagger
-      - run: go get github.com/sqs/goreturns@master
       - run: |
           bash <(curl https://raw.githubusercontent.com/ory/cli/master/install.sh) -b $GOPATH/bin
       - run: swagger generate spec -m -o <<parameters.swagpath>> $(printf -- " -x %s" <<parameters.specignorepgks>>)


### PR DESCRIPTION
`goreturns` is never used, and not used at all in most of our projects any more.