### PR TITLE
fix(changelog): remove npm version

### DIFF
--- a/src/scripts/changelog/generate.sh
+++ b/src/scripts/changelog/generate.sh
@@ -17,7 +17,6 @@ else
   isRelease=1
 fi
 
-npm --no-git-tag-version version "$CIRCLE_TAG"
 git clone git@github.com:ory/changelog.git "$preset"
 (cd "$preset"; npm i)
 


### PR DESCRIPTION
The effect of the command is to update `jq ".version" package.json`, but the effect of that was never committed. Also, it does not seem to be necessary for the rest of the script, as it works as expected without (tested manually).

This will fix some CI tasks when the last tag is a go submodule: https://app.circleci.com/pipelines/github/ory/keto/1379/workflows/73723b11-e588-422c-b35f-6febb8d099ac/jobs/9028