### PR TITLE
ci: correctly pass `GORELEASER_KEY` env var

### DIFF
--- a/releaser/action.yml
+++ b/releaser/action.yml
@@ -70,11 +70,10 @@ runs:
       with:
         install-only: true
         distribution: goreleaser-pro
-      env:
-        GORELEASER_KEY: ${{ inputs.goreleaser_key }}
 
     - env:
         GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+        GORELEASER_KEY: ${{ inputs.goreleaser_key }}
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         cat "$notes"


### PR DESCRIPTION
The `GORELEASER_KEY` environment variable was previously being passed incorrectly to the job above.