### PR TITLE
fix: specify shell in newsletter action

### DIFF
--- a/newsletter/action.yml
+++ b/newsletter/action.yml
@@ -36,3 +36,4 @@ runs:
           echo "inputs.draft should be either 'true' or 'false'"
           exit 1
         fi
+      shell: bash


### PR DESCRIPTION
The `newsletter` action was missing the `shell` property which is required to run.