### PR TITLE
fix: use $notes file as is

### DIFF
--- a/releaser/action.yml
+++ b/releaser/action.yml
@@ -82,7 +82,7 @@ runs:
             -e GITHUB_TOKEN=$GITHUB_TOKEN \
             -e GORELEASER_CURRENT_TAG=$GORELEASER_CURRENT_TAG \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            oryd/xgoreleaser:latest release --release-header <(cat "$notes") --rm-dist --timeout 60m --parallelism 1
+            oryd/xgoreleaser:latest release --release-header "$notes" --rm-dist --timeout 60m --parallelism 1
 
         git add -A
         git stash || true


### PR DESCRIPTION
The <(...) syntax breaks in docker because the /dev/fd/63 file
descriptor isn't mounted.