### PR TITLE
fix: no-op if previous commit was autogen

### DIFF
--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -65,13 +65,29 @@ runs:
         t=$(mktemp)
         printf "# Changelog\n\n" | cat - CHANGELOG.md > "$t" && mv "$t" CHANGELOG.md
 
-        git stash || true
-        git checkout master || true
-        git stash pop || true
-        git add CHANGELOG.md
-        git commit -m "autogen(docs): regenerate and update changelog" || true
-        git pull origin master --rebase || true
-        if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-          git push origin "$GITHUB_REF_NAME" || true
+
+        if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
+          if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
+            echo "No-op because the previous commit was autogen"
+          else
+            git commit -m "autogen(docs): regenerate and update changelog" || true
+            git pull -ff || true
+            git push origin HEAD:"$GITHUB_REF_NAME" || true
+          fi
+        else
+          if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
+            echo "No-op because the previous commit was autogen"
+          else
+            git fetch origin
+            git stash
+            git checkout -b "changelog-$(date +"%m-%d-%Y")" origin/master
+            git pull -ff
+            git stash pop
+            (
+              git commit -m "autogen(docs): regenerate and update changelog" &&
+              git pull -ff &&
+              git push origin HEAD:master
+            ) || true
+          fi
         fi
       shell: bash

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -61,33 +61,29 @@ runs:
           npm run format
         fi
 
-
         t=$(mktemp)
         printf "# Changelog\n\n" | cat - CHANGELOG.md > "$t" && mv "$t" CHANGELOG.md
-
-
-        if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
-          if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
-            echo "No-op because the previous commit was autogen"
-          else
-            git commit -m "autogen(docs): regenerate and update changelog" || true
-            git pull -ff || true
-            git push origin HEAD:"$GITHUB_REF_NAME" || true
-          fi
-        else
-          if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
-            echo "No-op because the previous commit was autogen"
-          else
-            git fetch origin
-            git stash
-            git checkout -b "changelog-$(date +"%m-%d-%Y")" origin/master
-            git pull -ff
-            git stash pop
-            (
-              git commit -m "autogen(docs): regenerate and update changelog" &&
-              git pull -ff &&
-              git push origin HEAD:master
-            ) || true
-          fi
-        fi
+      shell: bash
+    - run: |
+        echo "::set-output name=msg::$(git log --format=%B -n1)"
+      shell: bash
+      id: commit-msg
+    - if: ${{ github.ref_type != 'tag' && !startsWith(steps.commit-msg.outputs.msg, 'autogen') }}
+      run: |
+        git commit -m "autogen(docs): regenerate and update changelog" || true
+        git pull -ff || true
+        git push origin HEAD:"$GITHUB_REF_NAME" || true
+      shell: bash
+    - if ${{ github.ref_type == 'tag' }}
+      run: |
+        git fetch origin
+        git stash
+        git checkout -b "changelog-$(date +"%m-%d-%Y")" origin/master
+        git pull -ff
+        git stash pop
+        (
+          git commit -m "autogen(docs): regenerate and update changelog" &&
+          git pull -ff &&
+          git push origin HEAD:master
+        ) || true
       shell: bash

--- a/docs/build/action.yml
+++ b/docs/build/action.yml
@@ -46,31 +46,36 @@ runs:
           npm run build
           npm run format
         )
-
-        if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-          branch="$(date +%s)"
-          git checkout -b "$branch"
-          git add -A
-          git commit --allow-empty -a -m "autogen(docs): generate and format documentation"
-          git pull origin master --rebase
-          git push origin HEAD:master
-        else
-          if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
-            echo "No-op because the previous commit was autogen"
-          else
-            git add -A
-            git commit --allow-empty -a -m "autogen(docs): generate and format documentation"
-            if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-              git pull origin "$GITHUB_REF_NAME" --rebase
-              git push origin "$GITHUB_REF_NAME" || true
-            fi
-          fi
-        fi
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         SWAG_SPEC_LOCATION: ${{ inputs.swag-spec-location }}
         SWAG_SPEC_IGNORE: ${{ inputs.swag-spec-ignore }}
+    - run: |
+        cd current-repo
+        echo "::set-output name=msg::$(git log --format=%B -n1)"
+      shell: bash
+      id: commit-msg
+    - if: ${{ github.ref_type != 'tag' && !startsWith(steps.commit-msg.outputs.msg, 'autogen') }}
+      run: |
+        cd current-repo
+        branch="$(date +%s)"
+        git checkout -b "$branch"
+        git add -A
+        git commit --allow-empty -a -m "autogen(docs): generate and format documentation"
+        git pull origin master --rebase
+        git push origin HEAD:master
+      shell: bash
+    - if ${{ github.ref_type == 'tag' }}
+      run: |
+        cd current-repo
+        git add -A
+        git commit --allow-empty -a -m "autogen(docs): generate and format documentation"
+        if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
+          git pull origin "$GITHUB_REF_NAME" --rebase
+          git push origin "$GITHUB_REF_NAME" || true
+        fi
+      shell: bash
     - uses: actions/checkout@v2
       with:
         repository: ory/web

--- a/docs/build/action.yml
+++ b/docs/build/action.yml
@@ -55,13 +55,16 @@ runs:
           git pull origin master --rebase
           git push origin HEAD:master
         else
-          git add -A
-          git commit --allow-empty -a -m "autogen(docs): generate and format documentation"
-          git pull origin master --rebase
-          if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-            git push origin "$GITHUB_REF_NAME" || true
+          if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
+            echo "No-op because the previous commit was autogen"
+          else
+            git add -A
+            git commit --allow-empty -a -m "autogen(docs): generate and format documentation"
+            if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
+              git pull origin "$GITHUB_REF_NAME" --rebase
+              git push origin "$GITHUB_REF_NAME" || true
+            fi
           fi
-          git push origin master
         fi
       shell: bash
       env:

--- a/docs/cli/action.yml
+++ b/docs/cli/action.yml
@@ -33,17 +33,19 @@ runs:
       with:
         dir: current-repo/docs
         action: write
-    - env:
+    - run: |
+        cd current-repo
+        echo "::set-output name=msg::$(git log --format=%B -n1)"
+      shell: bash
+      id: commit-msg
+    - if: ${{ !startsWith(steps.commit-msg.outputs.msg, 'autogen') }}
+      env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash
       run: |
         cd current-repo
-        if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
-          echo "No-op because the previous commit was autogen"
-        else
-          git add -A
-          git commit -a -m "autogen(docs): generate cli docs" || true
-          if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-            git push origin HEAD:"$GITHUB_REF_NAME" || true
-          fi
+        git add -A
+        git commit -a -m "autogen(docs): generate cli docs" || true
+        if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
+          git push origin HEAD:"$GITHUB_REF_NAME" || true
         fi

--- a/docs/cli/action.yml
+++ b/docs/cli/action.yml
@@ -38,8 +38,12 @@ runs:
       shell: bash
       run: |
         cd current-repo
-        git add -A
-        git commit -a -m "autogen(docs): generate cli docs" || true
-        if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-          git push origin HEAD:"$GITHUB_REF_NAME" || true
+        if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
+          echo "No-op because the previous commit was autogen"
+        else
+          git add -A
+          git commit -a -m "autogen(docs): generate cli docs" || true
+          if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
+            git push origin HEAD:"$GITHUB_REF_NAME" || true
+          fi
         fi

--- a/sdk/generate/action.yml
+++ b/sdk/generate/action.yml
@@ -58,14 +58,17 @@ runs:
         mkdir -p ${{ inputs.swag-gen-path }}
 
         swagger generate client -f ${{ inputs.swag-spec-location }} -t ${{ inputs.swag-gen-path }} -A ${{ inputs.app-name }}
-
-        if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
-          echo "No-op because the previous commit was autogen"
-        else
-          git add -A
-          git commit -a -m "autogen(openapi): regenerate swagger spec and internal client" || true
-          if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-            git push origin HEAD:"$GITHUB_REF_NAME" || true
-          fi
+    - run: |
+        cd current-repo
+        echo "::set-output name=msg::$(git log --format=%B -n1)"
+      id: commit-msg
+      shell: bash
+    - if: ${{ !startsWith(steps.commit-msg.outputs.msg, 'autogen') }}
+      run: |
+        cd current-repo
+        git add -A
+        git commit -a -m "autogen(openapi): regenerate swagger spec and internal client" || true
+        if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
+          git push origin HEAD:"$GITHUB_REF_NAME" || true
         fi
       shell: bash

--- a/sdk/generate/action.yml
+++ b/sdk/generate/action.yml
@@ -59,13 +59,13 @@ runs:
 
         swagger generate client -f ${{ inputs.swag-spec-location }} -t ${{ inputs.swag-gen-path }} -A ${{ inputs.app-name }}
 
-        git add -A
-        git stash || true
-        git checkout master || true
-        git stash pop || true
-        git commit -a -m "autogen(openapi): regenerate swagger spec and internal client" || true
-        git pull origin master --rebase || true
-        if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-          git push origin "$GITHUB_REF_NAME" || true
+        if [[ "$(git log --format=%B -n1)" =~ "autogen"* ]]; then
+          echo "No-op because the previous commit was autogen"
+        else
+          git add -A
+          git commit -a -m "autogen(openapi): regenerate swagger spec and internal client" || true
+          if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
+            git push origin HEAD:"$GITHUB_REF_NAME" || true
+          fi
         fi
       shell: bash


### PR DESCRIPTION
In response to review comments over at
https://github.com/ory/hydra/pull/2955, this patch adds checks for
whether the previous commit was autogenerated; if yes, do nothing, else,
proceed with commit + push. 

Further, checks for whether to push to master (i.e. on a tag), or to
push to current branch (i.e. on a PR) are introduced.