### PR TITLE
chore: remove mention of CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,20 +129,3 @@ Usage:
 ```yaml
 uses: ory/ci/sdk/generate@ref
 ```
-
-## CircleCI
-
-To publish an orb, install the CLI and run:
-
-```
-orb=<name>
-circleci orb validate src/orbs/${orb}.yml
-circleci orb publish increment src/orbs/${orb}.yml ory/${orb} patch
-```
-
-To create a new orb, run:
-
-```
-orb=<name>
-circleci orb create ory/$orb
-```


### PR DESCRIPTION
Since CircleCI is no longer used, we don't need to document how to publish orbs to it.