### PR TITLE
fix: format changelog step

### DIFF
--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -22,6 +22,26 @@ runs:
       run: |
         curl -sSfL https://raw.githubusercontent.com/ory/ci/master/changelog/create_changelog.sh | bash
       shell: bash
+    - name: format the changelog
+      uses: ory/ci/prettier@master
+      with:
+        dir: .
+        action: write
+        target: CHANGELOG.md
+    # NOTE: need to format twice because of https://github.com/prettier/prettier/issues/13213
+    - name: format the changelog 2
+      uses: ory/ci/prettier@master
+      with:
+        dir: .
+        action: write
+        target: CHANGELOG.md
+    # NOTE: we add a safety check because of https://github.com/prettier/prettier/issues/13213
+    - name: check the changelog format
+      uses: ory/ci/prettier@master
+      with:
+        dir: .
+        action: check
+        target: CHANGELOG.md
     - name: commit the changes
       if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
       env:

--- a/changelog/create_changelog.sh
+++ b/changelog/create_changelog.sh
@@ -31,12 +31,5 @@ t=$(mktemp)
 printf "# Changelog\n\n" | cat - CHANGELOG.md >"$t" && mv "$t" CHANGELOG.md
 
 echo
-echo "FORMAT THE CHANGELOG ..."
-# NOTE: need to format twice because of https://github.com/prettier/prettier/issues/13213
-npx --yes prettier@2.7.1 --write CHANGELOG.md
-npx --yes prettier@2.7.1 --write CHANGELOG.md
-npx --yes prettier@2.7.1 --check CHANGELOG.md
-
-echo
 echo "CLEANUP ..."
 rm -rf changelog/


### PR DESCRIPTION
The CI currently fails because `ory-prettier-styles` is not installed. https://github.com/ory/kratos/actions/runs/3069421838/jobs/4958499397
Using the prettier composite action, we can ensure the correct (the project's) prettier version is used, and `ory-prettier-styles` is installed.