### PR TITLE
chore: format generated code before committing

### DIFF
--- a/sdk/generate/action.yml
+++ b/sdk/generate/action.yml
@@ -27,7 +27,7 @@ runs:
         token: ${{ inputs.token || github.token }}
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - run: |
         git config --global user.email "60093411+ory-bot@users.noreply.github.com"
         git config --global user.name "ory-bot"
@@ -66,6 +66,7 @@ runs:
       if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
       run: |
         cd current-repo
+        make format
         git add -A
         git commit -a -m "autogen(openapi): regenerate swagger spec and internal client" -m "[skip ci]" || true
       shell: bash


### PR DESCRIPTION
I noticed that auto-generated code isn't properly formatted, even though `make sdk` formats everything it generates. To be on the safe side, this runs `make format` again before committing the auto-generated changes. Make format should always succeed here because it already ran at this time.

This also changes the Go version used for generating the SDK to Go 1.19. Keto is already at this version. I try to enforce Go 1.19 code style across all repos.

Please advise how to test this.