### PR TITLE
ci: unshallow checkout

### DIFF
--- a/changelog/create_changelog.sh
+++ b/changelog/create_changelog.sh
@@ -14,6 +14,7 @@ fi
 echo
 echo "FETCH GIT METADATA ..."
 git fetch origin +refs/tags/*:refs/tags/*
+git fetch --unshallow
 
 echo
 echo "INSTALL TOOLS ..."

--- a/newsletter/action.yml
+++ b/newsletter/action.yml
@@ -41,6 +41,7 @@ runs:
         SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         git fetch origin +refs/tags/*:refs/tags/*
+        git fetch --unshallow
         bash <(curl https://raw.githubusercontent.com/ory/meta/master/install.sh) -b . ory 
         if [[ "${{ inputs.draft }}" == "false" ]]; then
           # production run

--- a/releaser/action.yml
+++ b/releaser/action.yml
@@ -68,6 +68,7 @@ runs:
         )
 
         git fetch origin +refs/tags/*:refs/tags/*
+        git fetch --unshallow
 
         npx conventional-changelog-cli@v2.1.1 --config "changelog/index.js" -r 2 -o "$notes"
 


### PR DESCRIPTION
By default, actions/checkout uses a shallow checkout (`--depth=1`). For example, [here](https://github.com/ory/keto/actions/runs/3135793082/jobs/5092383310#step:2:69). This breaks our changelog generation in our ory/ci/newsletter action. This patch unshallows the checked out repository.