### PR TITLE
chore: bump go to 1.19

### DIFF
--- a/docs/build/action.yml
+++ b/docs/build/action.yml
@@ -24,7 +24,7 @@ runs:
         token: ${{ inputs.token }}
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - run: |
         git config --global user.email "60093411+ory-bot@users.noreply.github.com"
         git config --global user.name "ory-bot"

--- a/docs/cli-next/action.yml
+++ b/docs/cli-next/action.yml
@@ -27,7 +27,7 @@ runs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - run: |
         git config --global user.email "60093411+ory-bot@users.noreply.github.com"
         git config --global user.name "ory-bot"

--- a/docs/cli/action.yml
+++ b/docs/cli/action.yml
@@ -25,7 +25,7 @@ runs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - run: |
         git config --global user.email "60093411+ory-bot@users.noreply.github.com"
         git config --global user.name "ory-bot"

--- a/docs/sync/action.yml
+++ b/docs/sync/action.yml
@@ -24,7 +24,7 @@ runs:
         token: ${{ inputs.token }}
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - run: |
         git config --global user.email "60093411+ory-bot@users.noreply.github.com"
         git config --global user.name "ory-bot"

--- a/releaser/action.yml
+++ b/releaser/action.yml
@@ -30,7 +30,7 @@ runs:
         node-version: '16'
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - run: |
         git config --global user.email "60093411+ory-bot@users.noreply.github.com"
         git config --global user.name "ory-bot"

--- a/releaser/render-version-schema/action.yml
+++ b/releaser/render-version-schema/action.yml
@@ -21,7 +21,7 @@ runs:
         node-version: '16'
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - run: |
         git config --global user.email "60093411+ory-bot@users.noreply.github.com"
         git config --global user.name "ory-bot"

--- a/sdk/release/action.yml
+++ b/sdk/release/action.yml
@@ -18,7 +18,7 @@ runs:
         path: current-repo
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - run: |
         git config --global user.email "60093411+ory-bot@users.noreply.github.com"
         git config --global user.name "ory-bot"


### PR DESCRIPTION
ory/x requires go1.19 since https://github.com/ory/x/commit/b08c584b1767cecee7f6b46bbf57695e475d9e68 because of "no breaking changes" in go1 :roll_eyes: 