### PR TITLE
feat: write latest version to file in SDK client dir

### DIFF
--- a/sdk/release/action.yml
+++ b/sdk/release/action.yml
@@ -1,5 +1,5 @@
-name: 'SDK Release'
-description: 'SDK release automation'
+name: "SDK Release"
+description: "SDK release automation"
 inputs:
   token:
     description: Personal access token
@@ -47,6 +47,7 @@ runs:
         repo="${x[1]}"
 
         cp current-repo/${{ inputs.swag-spec-location }} "sdk/spec/$repo/$GITHUB_REF_NAME.json"
+        echo "$GITHUB_REF_NAME" > "sdk/spec/$repo/latest"
         cd sdk
 
         git add -A


### PR DESCRIPTION
This adds a file called `latest` to the various client SDK directories inside the `ory/sdk` repository when releasing a new spec to the repo.

This is needed to execute CI PR validations, as we are no longer dependent on the commit message to find the latest version. With this change, we can simply `cat` (read) the content of the `latest` file in the directory and run validations against that spec.