### PR TITLE
Extract license list tool from license checker tool

### DIFF
--- a/licenses/install
+++ b/licenses/install
@@ -13,6 +13,8 @@ curl https://raw.githubusercontent.com/ory/ci/master/licenses/license-engine.sh 
 chmod +x .bin/license-engine.sh
 curl https://raw.githubusercontent.com/ory/ci/master/licenses/licenses -o .bin/licenses
 chmod +x .bin/licenses
+curl https://raw.githubusercontent.com/ory/ci/master/licenses/list-licenses -o .bin/list-licenses
+chmod +x .bin/list-licenses
 
 if [ -f go.mod ]; then
 	{

--- a/licenses/licenses
+++ b/licenses/licenses
@@ -1,21 +1,5 @@
 #!/bin/sh
 set -e
 
-# check Node licenses
-if [ -f package.json ]; then
-	{ echo "Checking Node licenses ..."; } 2>/dev/null
-	npm exec -- license-checker --csv --production --excludePrivatePackages --customPath .bin/license-template-node.json | .bin/license-engine.sh
-	{ echo; } 2>/dev/null
-fi
-
-# check Go licenses
-if [ -f go.mod ]; then
-	{ echo "Checking Go licenses ..."; } 2>/dev/null
-	module_name=$(grep "^module" go.mod | awk '{print $2}')
-	if [ -z "$module_name" ]; then
-		echo "Cannot determine the Go module name"
-		exit 1
-	fi
-	.bin/go-licenses report "$module_name" --template .bin/license-template-go.tpl 2>/dev/null | .bin/license-engine.sh
-	{ echo; } 2>/dev/null
-fi
+{ echo "Checking licenses ..."; } 2>/dev/null
+.bin/list-licenses | .bin/license-engine.sh

--- a/licenses/list-licenses
+++ b/licenses/list-licenses
@@ -11,7 +11,7 @@ fi
 if [ -f go.mod ]; then
 	module_name=$(grep "^module" go.mod | awk '{print $2}')
 	if [ -z "$module_name" ]; then
-		>&2 echo "Cannot determine the Go module name"
+		echo "Cannot determine the Go module name" >&2
 		exit 1
 	fi
 	.bin/go-licenses report "$module_name" --template .bin/license-template-go.tpl 2>/dev/null

--- a/licenses/list-licenses
+++ b/licenses/list-licenses
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# check Node licenses
+if [ -f package.json ]; then
+	npm exec --yes license-checker -- --csv --production --excludePrivatePackages --customPath .bin/license-template-node.json
+	{ echo; } 2>/dev/null
+fi
+
+# check Go licenses
+if [ -f go.mod ]; then
+	module_name=$(grep "^module" go.mod | awk '{print $2}')
+	if [ -z "$module_name" ]; then
+		>&2 echo "Cannot determine the Go module name"
+		exit 1
+	fi
+	.bin/go-licenses report "$module_name" --template .bin/license-template-go.tpl 2>/dev/null
+	{ echo; } 2>/dev/null
+fi

--- a/licenses/list-licenses
+++ b/licenses/list-licenses
@@ -1,13 +1,13 @@
 #!/bin/sh
 set -e
 
-# check Node licenses
+# list Node licenses
 if [ -f package.json ]; then
 	npm exec --yes license-checker -- --csv --production --excludePrivatePackages --customPath .bin/license-template-node.json
 	{ echo; } 2>/dev/null
 fi
 
-# check Go licenses
+# list Go licenses
 if [ -f go.mod ]; then
 	module_name=$(grep "^module" go.mod | awk '{print $2}')
 	if [ -z "$module_name" ]; then


### PR DESCRIPTION
The current license tool enumerates all licenses and directly checks that list for irregular licenses. This PR extracts the logic for determining license identifiers out into a dedicated script. This enables compiling a list of licenses used across Ory projects. No changes to the business logic.