### PR TITLE
fix: resolve licenses for versioned modules and module-only roots

### DIFF
--- a/licenses/list-licenses
+++ b/licenses/list-licenses
@@ -16,23 +16,23 @@ fi
 
 # list Go licenses
 if [ -f go.mod ]; then
-	# List all direct Go module dependencies, transform their paths to root module paths
-	# (e.g., github.com/ory/x instead of github.com/ory/x/foo/bar), and generate a license report
-	# for each unique root module. This ensures that the license report is generated for the root
-	# module of a repository, where licenses are typically defined.
-	go_modules=$(
-		go list -f "{{if not .Indirect}}{{.Path}}{{end}}" -m ... |
-			sort -u |
-			awk -F/ '{ if ($1 == "github.com" && NF >= 3) { print $1"/"$2"/"$3 } else { print } }' |
-			sort -u
+	# For each direct Go module dependency, pick one importable package and let
+	# go-licenses report on it. Calling `go-licenses report <module>` directly
+	# does not work for two common cases:
+	#   - Versioned modules carry a /vN suffix that must be present verbatim
+	#     (github.com/golang-jwt/jwt/v5, github.com/dgraph-io/ristretto/v2).
+	#   - Some module roots have no Go file of their own; only sub-packages
+	#     are importable (cloud.google.com/go/secretmanager -> .../apiv1).
+	# Walking the actual import graph with `go list -deps` sidesteps both.
+	go_packages=$(
+		go list -deps -f '{{if .Module}}{{if not .Module.Main}}{{if not .Module.Indirect}}{{.Module.Path}}|{{.ImportPath}}{{end}}{{end}}{{end}}' ./... |
+			sort -u -t'|' -k1,1 |
+			cut -d'|' -f2
 	)
-	if [ -z "$go_modules" ]; then
+	if [ -z "$go_packages" ]; then
 		echo "No Go modules found" >&2
 	else
-		# Workaround until https://github.com/google/go-licenses/issues/307 is fixed
-		# .bin/go-licenses report "$module_name" --template .bin/license-template-go.tpl 2>/dev/null
-		#
-		echo "$go_modules" | xargs -I {} sh -c '.bin/go-licenses report --template .bin/license-template-go.tpl {}' | grep -v '^$'
+		echo "$go_packages" | xargs -I {} sh -c '.bin/go-licenses report --template .bin/license-template-go.tpl {}' | grep -v '^$'
 		echo
 	fi
 fi


### PR DESCRIPTION
## Summary

Replace the module-path string munging in `list-licenses` with a `go list -deps` walk that picks one importable package per direct module and feeds those to `go-licenses report`.

Calling `go-licenses report <module>` directly does not work for two common patterns:

- **Versioned modules** carry a `/vN` suffix that must be present verbatim. The previous awk truncated paths like `github.com/dgraph-io/ristretto/v2` to `github.com/dgraph-io/ristretto`, which is not a valid module path for v2+ modules.
- **Module roots with no Go file of their own**, where only sub-packages are importable. `cloud.google.com/go/secretmanager` is an example: only `apiv1/...` exists as a package, so `go list` on the root returns `no required module provides package` and `go-licenses` exits fatally.

Walking the actual import graph sidesteps both problems and removes the workaround referenced in the old comment (https://github.com/google/go-licenses/issues/307).

## Behavior change

The old script reported one row per direct module using the module's root LICENSE. The new script reports one row per imported package, which inherits the same LICENSE in nearly all cases but more accurately reflects what is actually linked into the binary.

## Test plan

- [x] Ran the patched script against several Go modules locally; license-engine reports `Licenses are okay.` for each.
- [x] Confirmed the patched script resolves the regression for modules with `/vN` suffixes and for modules whose root is not an importable package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated license enumeration logic to comprehensively include all transitive dependencies in license reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/ci/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->